### PR TITLE
Enabling Surefire to output the all test class order in one XML format

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/ForkClient.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/ForkClient.java
@@ -95,6 +95,7 @@ public class ForkClient
         this.forkNumber = forkNumber;
         notifier.setTestSetStartingListener( new TestSetStartingListener() );
         notifier.setTestSetCompletedListener( new TestSetCompletedListener() );
+        notifier.setAllTestSetCompletedListener( new AllTestSetCompletedListener() );
         notifier.setTestStartingListener( new TestStartingListener() );
         notifier.setTestSucceededListener( new TestSucceededListener() );
         notifier.setTestFailedListener( new TestFailedListener() );
@@ -137,6 +138,16 @@ public class ForkClient
                     reportEntry.getGroup(), reportEntry.getStackTraceWriter(), reportEntry.getElapsed(),
                     reportEntry.getMessage(), getTestVmSystemProperties() );
             getTestSetReporter().testSetCompleted( entry );
+        }
+    }
+
+    private final class AllTestSetCompletedListener
+        implements ForkedProcessEventListener
+    {
+        public void handle()
+        {
+            testsInProgress.clear();
+            getTestSetReporter().allTestSetCompleted();
         }
     }
 

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/ForkedProcessEventNotifier.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/ForkedProcessEventNotifier.java
@@ -45,6 +45,7 @@ import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTER
 import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTERCODE_STDOUT_NEW_LINE;
 import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTERCODE_STOP_ON_NEXT_TEST;
 import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTERCODE_TESTSET_COMPLETED;
+import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTERCODE_ALLTESTSET_COMPLETED;
 import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTERCODE_TESTSET_STARTING;
 import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTERCODE_TEST_ASSUMPTIONFAILURE;
 import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTERCODE_TEST_ERROR;
@@ -157,6 +158,11 @@ public final class ForkedProcessEventNotifier
     public void setByeListener( ForkedProcessEventListener listener )
     {
         controlEventListeners.put( BOOTERCODE_BYE, requireNonNull( listener ) );
+    }
+
+    public void setAllTestSetCompletedListener( ForkedProcessEventListener listener )
+    {
+        controlEventListeners.put( BOOTERCODE_ALLTESTSET_COMPLETED, requireNonNull( listener ) );
     }
 
     public void setStopOnNextTestListener( ForkedProcessEventListener listener )

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullStatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullStatelessXmlReporter.java
@@ -42,6 +42,11 @@ class NullStatelessXmlReporter
     }
 
     @Override
+    public void allTestSetCompleted()
+    {
+    }
+
+    @Override
     public void cleanTestHistoryMap()
     {
     }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
@@ -20,7 +20,6 @@ package org.apache.maven.plugin.surefire.report;
  */
 
 import org.apache.maven.plugin.surefire.booterclient.output.InPluginProcessDumpSingleton;
-import org.apache.maven.surefire.api.runorder.RunEntryStatistics;
 import org.apache.maven.surefire.shared.utils.xml.PrettyPrintXMLWriter;
 import org.apache.maven.surefire.shared.utils.xml.XMLWriter;
 import org.apache.maven.surefire.extensions.StatelessReportEventListener;
@@ -34,8 +33,14 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -194,7 +199,8 @@ public class StatelessXmlReporter
             Iterator<WrappedReportEntry> itr = allTestSetReportEntry.iterator();
             Iterator<TestSetStats> its = allTestSetStats.iterator();
 
-            while( itr.hasNext() && its.hasNext() ){
+            while ( itr.hasNext() && its.hasNext() )
+            {
                 WrappedReportEntry testSetReportEntry = itr.next();
                 TestSetStats testSetStats = its.next();
                 createTestSuiteElement( allClassPpw, testSetReportEntry, testSetStats, true ); // TestSuite
@@ -489,7 +495,8 @@ public class StatelessXmlReporter
         Iterator<WrappedReportEntry> itr = reports.iterator();
         Iterator<TestSetStats> its = testAllSetStats.iterator();
 
-        while( itr.hasNext() && its.hasNext() ){
+        while ( itr.hasNext() && its.hasNext() )
+        {
             WrappedReportEntry report = itr.next();
             TestSetStats testSetStats = its.next();
             totalTime += report.getElapsed();
@@ -515,7 +522,8 @@ public class StatelessXmlReporter
     {
         ppw.startElement( "testclass" );
 
-        if ( !allClass ){
+        if ( !allClass )
+        {
             ppw.addAttribute( "xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance" );
             ppw.addAttribute( "xsi:noNamespaceSchemaLocation", xsdSchemaLocation );
             ppw.addAttribute( "version", xsdVersion );

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
@@ -20,6 +20,7 @@ package org.apache.maven.plugin.surefire.report;
  */
 
 import org.apache.maven.plugin.surefire.booterclient.output.InPluginProcessDumpSingleton;
+import org.apache.maven.surefire.api.runorder.RunEntryStatistics;
 import org.apache.maven.surefire.shared.utils.xml.PrettyPrintXMLWriter;
 import org.apache.maven.surefire.shared.utils.xml.XMLWriter;
 import org.apache.maven.surefire.extensions.StatelessReportEventListener;
@@ -33,19 +34,15 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.maven.plugin.surefire.report.DefaultReporterFactory.TestResultType;
 import static org.apache.maven.plugin.surefire.report.FileReporterUtils.stripIllegalFilenameChars;
 import static org.apache.maven.plugin.surefire.report.ReportEntryType.SUCCESS;
+import static org.apache.maven.plugin.surefire.report.ReporterUtils.formatElapsedTime;
 import static org.apache.maven.surefire.shared.utils.StringUtils.isBlank;
 
 @SuppressWarnings( { "javadoc", "checkstyle:javadoctype" } )
@@ -110,6 +107,16 @@ public class StatelessXmlReporter
 
     private final boolean phrasedMethodName;
 
+    private static OutputStream allClassOutStream = null;
+
+    private static OutputStreamWriter allClassFw = null;
+
+    private static XMLWriter allClassPpw = null;
+
+    private static List<WrappedReportEntry> allTestSetReportEntry = new ArrayList<>();
+
+    private static List<TestSetStats> allTestSetStats = new ArrayList<>();
+
     public StatelessXmlReporter( File reportsDirectory, String reportNameSuffix, boolean trimStackTrace,
                                  int rerunFailingTestsCount,
                                  Map<String, Deque<WrappedReportEntry>> testClassMethodRunHistoryMap,
@@ -141,7 +148,7 @@ public class StatelessXmlReporter
             XMLWriter ppw = new PrettyPrintXMLWriter( fw );
             ppw.setEncoding( UTF_8.name() );
 
-            createTestSuiteElement( ppw, testSetReportEntry, testSetStats ); // TestSuite
+            createTestSuiteElement( ppw, testSetReportEntry, testSetStats, false ); // TestSuite
 
             showProperties( ppw, testSetReportEntry.getSystemProperties() );
 
@@ -162,6 +169,56 @@ public class StatelessXmlReporter
             // The control flow must not be broken in TestSetRunListener#testSetCompleted.
             InPluginProcessDumpSingleton.getSingleton()
                     .dumpException( e, e.getLocalizedMessage(), reportsDirectory );
+        }
+
+        allTestSetReportEntry.add( testSetReportEntry );
+        allTestSetStats.add( testSetStats );
+    }
+
+    @Override
+    public void allTestSetCompleted()
+    {
+        if ( allClassOutStream == null )
+        {
+            allClassOutStream = getAllClassOutputStream();
+            allClassFw = getWriter( allClassOutStream );
+            allClassPpw = new PrettyPrintXMLWriter( allClassFw );
+            allClassPpw.setEncoding( UTF_8.name() );
+        }
+        try
+        {
+            createAllTestSuiteElement( allClassPpw, allTestSetReportEntry, allTestSetStats );
+
+            //showProperties( allClassPpw, testSetReportEntry.getSystemProperties() );
+
+            Iterator<WrappedReportEntry> itr = allTestSetReportEntry.iterator();
+            Iterator<TestSetStats> its = allTestSetStats.iterator();
+
+            while( itr.hasNext() && its.hasNext() ){
+                WrappedReportEntry testSetReportEntry = itr.next();
+                TestSetStats testSetStats = its.next();
+                createTestSuiteElement( allClassPpw, testSetReportEntry, testSetStats, true ); // TestSuite
+
+                Map<String, Map<String, List<WrappedReportEntry>>> classMethodStatistics =
+                    arrangeMethodStatistics( testSetReportEntry, testSetStats );
+
+                for ( Entry<String, Map<String, List<WrappedReportEntry>>> statistics : classMethodStatistics.entrySet() )
+                {
+                    for ( Entry<String, List<WrappedReportEntry>> thisMethodRuns : statistics.getValue().entrySet() )
+                    {
+                        serializeTestClass( allClassOutStream, allClassFw, allClassPpw, thisMethodRuns.getValue() );
+                    }
+                }
+            }
+
+            allClassPpw.endElement(); //AllClass TestSuite
+            allClassFw.flush();
+            allClassOutStream.flush();
+        }
+        catch ( Exception e )
+        {
+            InPluginProcessDumpSingleton.getSingleton()
+                .dumpException( e, e.getLocalizedMessage(), reportsDirectory );
         }
     }
 
@@ -357,6 +414,24 @@ public class StatelessXmlReporter
         }
     }
 
+    private OutputStream getAllClassOutputStream()
+    {
+        File reportFile = getAllClassReportFile();
+
+        File reportDir = reportFile.getParentFile();
+
+        reportDir.mkdirs();
+
+        try
+        {
+            return new BufferedOutputStream( new FileOutputStream( reportFile ), 64 * 1024 );
+        }
+        catch ( Exception e )
+        {
+            throw new ReporterException( "When writing AllClass report", e );
+        }
+    }
+
     private static OutputStreamWriter getWriter( OutputStream fos )
     {
         return new OutputStreamWriter( fos, UTF_8 );
@@ -368,6 +443,12 @@ public class StatelessXmlReporter
         String customizedReportName = isBlank( reportNameSuffix ) ? reportName : reportName + "-" + reportNameSuffix;
         return new File( reportsDirectory, stripIllegalFilenameChars( customizedReportName + ".xml" ) );
     }
+
+    private File getAllClassReportFile()
+    {
+        return new File( reportsDirectory, stripIllegalFilenameChars( "TEST-ALLCLASS.xml" ) );
+    }
+
 
     private void startTestElement( XMLWriter ppw, WrappedReportEntry report )
     {
@@ -390,13 +471,55 @@ public class StatelessXmlReporter
         ppw.addAttribute( "time", report.elapsedTimeAsString() );
     }
 
-    private void createTestSuiteElement( XMLWriter ppw, WrappedReportEntry report, TestSetStats testSetStats )
+    private void createAllTestSuiteElement( XMLWriter ppw, List<WrappedReportEntry> reports,
+                                            List<TestSetStats> testAllSetStats )
     {
         ppw.startElement( "testsuite" );
 
         ppw.addAttribute( "xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance" );
         ppw.addAttribute( "xsi:noNamespaceSchemaLocation", xsdSchemaLocation );
         ppw.addAttribute( "version", xsdVersion );
+
+        double totalTime = 0;
+        int totalTests = 0;
+        int totalErrors = 0;
+        int totalSkipped = 0;
+        int totalFailures = 0;
+
+        Iterator<WrappedReportEntry> itr = reports.iterator();
+        Iterator<TestSetStats> its = testAllSetStats.iterator();
+
+        while( itr.hasNext() && its.hasNext() ){
+            WrappedReportEntry report = itr.next();
+            TestSetStats testSetStats = its.next();
+            totalTime += report.getElapsed();
+            totalTests += testSetStats.getErrors();
+            totalErrors += testSetStats.getErrors();
+            totalSkipped += testSetStats.getSkipped();
+            totalFailures += testSetStats.getFailures();
+        }
+
+        ppw.addAttribute( "time", formatElapsedTime( totalTime ) );
+
+        ppw.addAttribute( "tests", String.valueOf( totalTests ) );
+
+        ppw.addAttribute( "errors", String.valueOf( totalErrors ) );
+
+        ppw.addAttribute( "skipped", String.valueOf( totalSkipped ) );
+
+        ppw.addAttribute( "failures", String.valueOf( totalFailures ) );
+    }
+
+    private void createTestSuiteElement( XMLWriter ppw, WrappedReportEntry report, TestSetStats testSetStats,
+                                         boolean allClass )
+    {
+        ppw.startElement( "testclass" );
+
+        if ( !allClass ){
+            ppw.addAttribute( "xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance" );
+            ppw.addAttribute( "xsi:noNamespaceSchemaLocation", xsdSchemaLocation );
+            ppw.addAttribute( "version", xsdVersion );
+        }
 
         String reportName = phrasedSuiteName ? report.getReportSourceName( reportNameSuffix )
                 : report.getSourceName( reportNameSuffix );

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
@@ -204,6 +204,11 @@ public class TestSetRunListener
         clearCapture();
     }
 
+    public void allTestSetCompleted()
+    {
+        simpleXMLReporter.allTestSetCompleted();
+    }
+
     // ----------------------------------------------------------------------
     // Test callback methods:
     // ----------------------------------------------------------------------

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
@@ -186,15 +186,6 @@ public class TestSetRunListener
     @Override
     public void testSetCompleted( TestSetReportEntry report )
     {
-        StackTraceElement stack[] = ( new Throwable() ).getStackTrace();
-        for ( int i = 0; i < stack.length; i++ )
-        {
-            StackTraceElement ste = stack[i];
-            System.out.println( ste.getClassName() + "." + ste.getMethodName() + "(...)" );
-            System.out.println( i + "--" + ste.getMethodName() );
-            System.out.println( i + "--" + ste.getFileName() );
-            System.out.println( i + "--" + ste.getLineNumber() );
-        }
         final WrappedReportEntry wrap = wrapTestSet( report );
         final List<String> testResults =
                 briefOrPlainFormat ? detailsForThis.getTestResults() : Collections.<String>emptyList();

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
@@ -186,6 +186,15 @@ public class TestSetRunListener
     @Override
     public void testSetCompleted( TestSetReportEntry report )
     {
+        StackTraceElement stack[] = ( new Throwable() ).getStackTrace();
+        for ( int i = 0; i < stack.length; i++ )
+        {
+            StackTraceElement ste = stack[i];
+            System.out.println( ste.getClassName() + "." + ste.getMethodName() + "(...)" );
+            System.out.println( i + "--" + ste.getMethodName() );
+            System.out.println( i + "--" + ste.getFileName() );
+            System.out.println( i + "--" + ste.getLineNumber() );
+        }
         final WrappedReportEntry wrap = wrapTestSet( report );
         final List<String> testResults =
                 briefOrPlainFormat ? detailsForThis.getTestResults() : Collections.<String>emptyList();

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetStats.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetStats.java
@@ -72,6 +72,19 @@ public class TestSetStats
         this.plainFormat = plainFormat;
     }
 
+    public TestSetStats countClone()
+    {
+        TestSetStats cloneTestSetStats = new TestSetStats( trimStackTrace, plainFormat );
+        cloneTestSetStats.completedCount = completedCount;
+        cloneTestSetStats.failures = failures;
+        cloneTestSetStats.skipped = skipped;
+        cloneTestSetStats.errors = errors;
+        cloneTestSetStats.completedCount = completedCount;
+        cloneTestSetStats.testStartAt = testStartAt;
+        cloneTestSetStats.lastStartAt = lastStartAt;
+        return cloneTestSetStats;
+    }
+
     public int getElapsedSinceTestSetStart()
     {
         return testSetStartAt > 0 ? (int) ( System.currentTimeMillis() - testSetStartAt ) : 0;

--- a/maven-surefire-common/src/main/java/org/apache/maven/surefire/stream/EventDecoder.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/surefire/stream/EventDecoder.java
@@ -42,6 +42,7 @@ import org.apache.maven.surefire.api.event.TestSkippedEvent;
 import org.apache.maven.surefire.api.event.TestStartingEvent;
 import org.apache.maven.surefire.api.event.TestSucceededEvent;
 import org.apache.maven.surefire.api.event.TestsetCompletedEvent;
+import org.apache.maven.surefire.api.event.AllTestsetCompletedEvent;
 import org.apache.maven.surefire.api.event.TestsetStartingEvent;
 import org.apache.maven.surefire.api.fork.ForkNodeArguments;
 import org.apache.maven.surefire.api.report.RunMode;
@@ -231,6 +232,7 @@ public class EventDecoder extends AbstractStreamDecoder<Event, ForkedProcessEven
             case BOOTERCODE_BYE:
             case BOOTERCODE_STOP_ON_NEXT_TEST:
             case BOOTERCODE_NEXT_TEST:
+            case BOOTERCODE_ALLTESTSET_COMPLETED:
                 return EVENT_WITHOUT_DATA;
             case BOOTERCODE_CONSOLE_ERROR:
             case BOOTERCODE_JVM_EXIT_ERROR:
@@ -316,6 +318,9 @@ public class EventDecoder extends AbstractStreamDecoder<Event, ForkedProcessEven
             case BOOTERCODE_TESTSET_COMPLETED:
                 checkArguments( runMode, memento, 10 );
                 return new TestsetCompletedEvent( runMode, toReportEntry( memento.getData() ) );
+            case BOOTERCODE_ALLTESTSET_COMPLETED:
+                checkArguments( memento, 0 );
+                return new AllTestsetCompletedEvent();
             case BOOTERCODE_TEST_STARTING:
                 checkArguments( runMode, memento, 10 );
                 return new TestStartingEvent( runMode, toReportEntry( memento.getData() ) );

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/MockReporter.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/MockReporter.java
@@ -89,6 +89,11 @@ public class MockReporter
     }
 
     @Override
+    public void allTestSetCompleted()
+    {
+    }
+
+    @Override
     public void testStarting( ReportEntry report )
     {
         events.add( TEST_STARTING );

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ForkedProcessEventType.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ForkedProcessEventType.java
@@ -66,6 +66,8 @@ public enum ForkedProcessEventType
      */
     BOOTERCODE_TESTSET_COMPLETED( "testset-completed" ),
 
+    BOOTERCODE_ALLTESTSET_COMPLETED( "alltestset-completed" ),
+
     /**
      * This is the opcode "test-starting". The frame is composed of segments and the separator characters ':'
      * <pre>
@@ -310,6 +312,7 @@ public enum ForkedProcessEventType
     {
         return this == BOOTERCODE_TESTSET_STARTING
                 || this == BOOTERCODE_TESTSET_COMPLETED
+                || this == BOOTERCODE_ALLTESTSET_COMPLETED
                 || this == BOOTERCODE_TEST_STARTING
                 || this == BOOTERCODE_TEST_SUCCEEDED
                 || this == BOOTERCODE_TEST_FAILED

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ForkingRunListener.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ForkingRunListener.java
@@ -78,9 +78,7 @@ public class ForkingRunListener
     @Override
     public void allTestSetCompleted()
     {
-        System.out.println( "$$$$$$$$$$$$$$$$ at allTestSetCompleted" );
-        System.out.println( "$$$$$$$$$$$$$$$$ at allTestSetCompleted" );
-        System.out.println( "$$$$$$$$$$$$$$$$ at allTestSetCompleted" );
+        target.allTestSetCompleted();
     }
 
     @Override

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ForkingRunListener.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ForkingRunListener.java
@@ -76,6 +76,11 @@ public class ForkingRunListener
     }
 
     @Override
+    public void allTestSetCompleted( )
+    {
+    }
+
+    @Override
     public void testStarting( ReportEntry report )
     {
         target.testStarting( report, trim );

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ForkingRunListener.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ForkingRunListener.java
@@ -76,8 +76,11 @@ public class ForkingRunListener
     }
 
     @Override
-    public void allTestSetCompleted( )
+    public void allTestSetCompleted()
     {
+        System.out.println( "$$$$$$$$$$$$$$$$ at allTestSetCompleted" );
+        System.out.println( "$$$$$$$$$$$$$$$$ at allTestSetCompleted" );
+        System.out.println( "$$$$$$$$$$$$$$$$ at allTestSetCompleted" );
     }
 
     @Override

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/MasterProcessChannelEncoder.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/MasterProcessChannelEncoder.java
@@ -42,6 +42,8 @@ public interface MasterProcessChannelEncoder
 
     void testSetCompleted( ReportEntry reportEntry, boolean trimStackTraces );
 
+    void allTestSetCompleted();
+
     void testStarting( ReportEntry reportEntry, boolean trimStackTraces );
 
     void testSucceeded( ReportEntry reportEntry, boolean trimStackTraces );

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/report/RunListener.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/report/RunListener.java
@@ -47,6 +47,11 @@ public interface RunListener
     void testSetCompleted( TestSetReportEntry report );
 
     /**
+     * Indicates end of all given test-sets
+     */
+    void allTestSetCompleted();
+
+    /**
      * Event fired when a test is about to start
      *
      * @param report The report entry to log for

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/spi/EventChannelEncoder.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/spi/EventChannelEncoder.java
@@ -56,6 +56,7 @@ import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTER
 import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTERCODE_STOP_ON_NEXT_TEST;
 import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTERCODE_SYSPROPS;
 import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTERCODE_TESTSET_COMPLETED;
+import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTERCODE_ALLTESTSET_COMPLETED;
 import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTERCODE_TESTSET_STARTING;
 import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTERCODE_TEST_ASSUMPTIONFAILURE;
 import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTERCODE_TEST_ERROR;
@@ -158,6 +159,12 @@ public class EventChannelEncoder extends EventEncoder implements MasterProcessCh
     public void testSetCompleted( ReportEntry reportEntry, boolean trimStackTraces )
     {
         encode( BOOTERCODE_TESTSET_COMPLETED, runMode, reportEntry, trimStackTraces, true );
+    }
+
+    @Override
+    public void allTestSetCompleted()
+    {
+        encodeOpcode( BOOTERCODE_ALLTESTSET_COMPLETED , true );
     }
 
     @Override

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/StatelessReportEventListener.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/StatelessReportEventListener.java
@@ -40,4 +40,6 @@ public interface StatelessReportEventListener<R extends TestSetReportEntry, S>
      * @param testSetStats <em>TestSetStats</em>
      */
      void testSetCompleted( R report, S testSetStats );
+
+     void allTestSetCompleted();
 }

--- a/surefire-providers/surefire-junit4/src/main/java/org/apache/maven/surefire/junit4/JUnit4Provider.java
+++ b/surefire-providers/surefire-junit4/src/main/java/org/apache/maven/surefire/junit4/JUnit4Provider.java
@@ -158,6 +158,7 @@ public class JUnit4Provider
                 {
                     executeTestSet( testToRun, reporter, notifier );
                 }
+                reporter.allTestSetCompleted();
             }
             finally
             {


### PR DESCRIPTION
All the content of original XML report of each class can be printed into TEST-ALLCLASS.xml.  
e.g. if I run` mvn test -pl ClassB,ClassA,ClassC`, then Surefire would output one file (TEST-ALLCLASS.xml) that first contains the test method results of ClassB, then the results of ClassA, then ClassC. 

The format of TEST-ALLCLASS.xml  contains 1 `testsuite` tag, that contains many `testclass` tags (which names `testsuite` originally) and the `testclass` tags then contain `testcase` tags. The `testsuite` tag also includes the sum of time, tests, fails, errors, skipped, ...
In the normal output XML, such as TEST-ClassATest, the old  `testsuite` tag is transformed to `testclass` as well.

Here is part of possible output `mvn test -Dsurefire.rerunFailingTestsCount=3` (add .txt because XML is not supported)
[TEST-ClassDTest.xml.txt](https://github.com/TestingResearchIllinois/maven-surefire/files/7669514/TEST-ClassDTest.xml.txt)
[TEST-ALLCLASS.xml.txt](https://github.com/TestingResearchIllinois/maven-surefire/files/7669513/TEST-ALLCLASS.xml.txt)


Notice: there are tons of old naming involving testsuite, which should be changed into testclass now, are maintained due to possible unexpected effect.