### PR TITLE
adding mvn argument to ignore the enforcer error

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository is a fork of Maven Surefire that contains two main modifications
 
 To use the plugin, please perform the following steps.
 
-1. Run ```mvn install -DskipTests -Drat.skip``` in this directory
+1. Run ```mvn install -DskipTests -Drat.skip -Denforcer.skip``` in this directory
 2. Copy ```surefire-changing-maven-extension/target/surefire-changing-maven-extension-1.0-SNAPSHOT.jar``` into your Maven installation's ```lib/ext``` directory. This [StackOverflow post](https://stackoverflow.com/a/39479104) may help indicate where your Maven installation is located
 
 The copying of the extension helps ensure that any project you run ```mvn test``` on will now use this custom version of Surefire and change certain settings (e.g., reuseForks to false) to prevent issues with fixing the ordering of tests. More information on how to use Maven extensions can be found [here](https://maven.apache.org/examples/maven-3-lifecycle-extensions.html#use-your-extension-in-your-build-s). Note that if you already have ```surefire-changing-maven-extension-1.0-SNAPSHOT.jar``` in your Maven installation's ```lib/ext``` you must first remove the jar before installing again.


### PR DESCRIPTION
Without that argument, I get the following error. Hence, I would like to add the mvn option with this command in README.

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M3:enforce (enforce-bytecode-version) on project surefire: Execution enforce-bytecode-version of goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M3:enforce failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M3:enforce: java.lang.NoSuchMethodError: org.apache.maven.shared.dependency.graph.DependencyGraphBuilder.buildDependencyGraph(Lorg/apache/maven/project/ProjectBuildingRequest;Lorg/apache/maven/artifact/resolver/filter/ArtifactFilter;)Lorg/apache/maven/shared/dependency/graph/DependencyNode;
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M3
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/home/shanto/.m2/repository/org/apache/maven/plugins/maven-enforcer-plugin/3.0.0-M3/maven-enforcer-plugin-3.0.0-M3.jar
[ERROR] urls[1] = file:/home/shanto/.m2/repository/org/codehaus/mojo/extra-enforcer-rules/1.5.1/extra-enforcer-rules-1.5.1.jar
[ERROR] urls[2] = file:/home/shanto/.m2/repository/org/apache/maven/shared/maven-dependency-tree/2.2/maven-dependency-tree-2.2.jar
[ERROR] urls[3] = file:/home/shanto/.m2/repository/org/eclipse/aether/aether-util/0.9.0.M2/aether-util-0.9.0.M2.jar
[ERROR] urls[4] = file:/home/shanto/.m2/repository/commons-codec/commons-codec/1.12/commons-codec-1.12.jar
[ERROR] urls[5] = file:/home/shanto/.m2/repository/org/apache/maven/shared/maven-common-artifact-filters/3.1.0/maven-common-artifact-filters-3.1.0.jar
[ERROR] urls[6] = file:/home/shanto/.m2/repository/org/apache/maven/shared/maven-shared-utils/3.1.0/maven-shared-utils-3.1.0.jar
[ERROR] urls[7] = file:/home/shanto/.m2/repository/commons-io/commons-io/2.5/commons-io-2.5.jar
[ERROR] urls[8] = file:/home/shanto/.m2/repository/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar
[ERROR] urls[9] = file:/home/shanto/.m2/repository/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7-noaop.jar
[ERROR] urls[10] = file:/home/shanto/.m2/repository/org/sonatype/aether/aether-util/1.7/aether-util-1.7.jar
[ERROR] urls[11] = file:/home/shanto/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar
[ERROR] urls[12] = file:/home/shanto/.m2/repository/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar
[ERROR] urls[13] = file:/home/shanto/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
[ERROR] urls[14] = file:/home/shanto/.m2/repository/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
[ERROR] urls[15] = file:/home/shanto/.m2/repository/org/codehaus/plexus/plexus-utils/3.3.0/plexus-utils-3.3.0.jar
[ERROR] urls[16] = file:/home/shanto/.m2/repository/org/apache/maven/enforcer/enforcer-api/3.0.0-M3/enforcer-api-3.0.0-M3.jar
[ERROR] urls[17] = file:/home/shanto/.m2/repository/junit/junit/4.11/junit-4.11.jar
[ERROR] urls[18] = file:/home/shanto/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
[ERROR] urls[19] = file:/home/shanto/.m2/repository/org/apache/maven/enforcer/enforcer-rules/3.0.0-M3/enforcer-rules-3.0.0-M3.jar
[ERROR] urls[20] = file:/home/shanto/.m2/repository/org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar
[ERROR] urls[21] = file:/home/shanto/.m2/repository/org/beanshell/bsh/2.0b4/bsh-2.0b4.jar
[ERROR] urls[22] = file:/home/shanto/.m2/repository/org/apache/maven/resolver/maven-resolver-util/1.4.1/maven-resolver-util-1.4.1.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
