### PR TITLE
Fix config preservation in surefire-changing-maven-extension

### DIFF
--- a/surefire-changing-maven-extension/src/main/java/fun/jvm/surefire/flaky/KPLifecycleParticipant.java
+++ b/surefire-changing-maven-extension/src/main/java/fun/jvm/surefire/flaky/KPLifecycleParticipant.java
@@ -227,16 +227,35 @@ public class KPLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 //		}
 
 		p.getDependencies().clear();
-		for (PluginExecution pe : p.getExecutions()) {
-
-			Xpp3Dom config = (Xpp3Dom) pe.getConfiguration();
-			if (config == null)
-				config = new Xpp3Dom("configuration");
-			rewriteSurefireExecutionConfig(config, testNG);
-			p.setConfiguration(config);
-			pe.setConfiguration(config);
+		Xpp3Dom globalConfig = (Xpp3Dom) p.getConfiguration();
+		if (p.getExecutions().isEmpty()) {
+			if (globalConfig == null) {
+				globalConfig = new Xpp3Dom("configuration");
+				p.setConfiguration(globalConfig);
+			}
+			rewriteSurefireExecutionConfig(globalConfig, testNG);
+			PluginExecution pe = new PluginExecution();
+			pe.setConfiguration(globalConfig);
 			for (Configurator c : configurators)
 				c.applyConfiguration(project, p, pe);
+		} else {
+			for (PluginExecution pe : p.getExecutions()) {
+				Xpp3Dom config = (Xpp3Dom) pe.getConfiguration();
+				if (config == null) {
+					if (globalConfig != null) {
+						config = new Xpp3Dom(globalConfig);
+					} else {
+						config = new Xpp3Dom("configuration");
+					}
+				} else if (globalConfig != null) {
+					config = Xpp3Dom.mergeXpp3Dom(config, globalConfig);
+				}
+				rewriteSurefireExecutionConfig(config, testNG);
+				p.setConfiguration(config);
+				pe.setConfiguration(config);
+				for (Configurator c : configurators)
+					c.applyConfiguration(project, p, pe);
+			}
 		}
 
 	}


### PR DESCRIPTION
This is a simple fix, merging the global plugin-level <configuration> block with the extension's, instead of overwriting it with its own properties (which caused some tests to fail).

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean install`).

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)