### PR TITLE
Honor testorder method order via Jupiter MethodOrderer in JUnit5 projects

### DIFF
--- a/surefire-providers/surefire-junit-platform/pom.xml
+++ b/surefire-providers/surefire-junit-platform/pom.xml
@@ -88,6 +88,12 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.8.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
@@ -20,7 +20,6 @@ package org.apache.maven.surefire.junitplatform;
  */
 
 import static java.util.Arrays.stream;
-import static java.util.Collections.emptyMap;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.logging.Level.WARNING;
@@ -43,6 +42,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -99,6 +99,24 @@ public class JUnitPlatformProvider
         this.launcher = launcher;
         filters = newFilters();
         configurationParameters = newConfigurationParameters();
+        registerTestOrderMethodOrderer();
+    }
+
+    /**
+     * When the run order specifies method order (e.g. {@code -Dsurefire.runOrder=testorder} with a
+     * {@code Class#method} list), the Jupiter engine ignores it unless a MethodOrderer is installed.
+     * Reuse the JUnit 4 method comparator and register {@link TestOrderMethodOrderer} as the default
+     * orderer so JUnit 5 honors the same method order.
+     */
+    private void registerTestOrderMethodOrderer()
+    {
+        Comparator<String> methodComparator = parameters.getRunOrderCalculator().comparatorForTestMethods();
+        if ( methodComparator != null )
+        {
+            TestOrderMethodOrderer.methodComparator = methodComparator;
+            configurationParameters.put( "junit.jupiter.testmethod.order.default",
+                    TestOrderMethodOrderer.class.getName() );
+        }
     }
 
     @Override
@@ -302,7 +320,7 @@ public class JUnitPlatformProvider
         String content = parameters.getProviderProperties().get( CONFIGURATION_PARAMETERS );
         if ( content == null )
         {
-            return emptyMap();
+            return new HashMap<>();
         }
         try ( StringReader reader = new StringReader( content ) )
         {

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/TestOrderMethodOrderer.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/TestOrderMethodOrderer.java
@@ -1,0 +1,73 @@
+package org.apache.maven.surefire.junitplatform;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Comparator;
+
+import org.junit.jupiter.api.MethodDescriptor;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.MethodOrdererContext;
+
+/**
+ * Orders test methods within a class by the {@code -Dsurefire.runOrder=testorder} specification.
+ *
+ * <p>The JUnit Platform (JUnit 5) provider hands whole classes to the Jupiter engine, which owns
+ * method order via the {@link MethodOrderer} SPI. The class-level testorder run order therefore cannot
+ * reach method order the way the JUnit 4 provider does. Registering this orderer as the default
+ * ({@code junit.jupiter.testmethod.order.default}) closes that gap: it reuses the same
+ * {@code comparatorForTestMethods()} the JUnit 4 path uses, so a {@code Class#method} order file
+ * controls method order on JUnit 5 too. Methods with no entry in the specification keep their
+ * discovery order (stable sort), and with no specification set this orderer does nothing.
+ */
+public class TestOrderMethodOrderer
+    implements MethodOrderer
+{
+    /**
+     * Set by {@link JUnitPlatformProvider} before execution when a testorder method comparator exists.
+     * The provider and this orderer share the surefire-junit-platform classloader, so a static handoff
+     * is sufficient and avoids serializing the whole specified order through configuration parameters.
+     * Compares keys of the form {@code methodName(fullyQualifiedClassName)}.
+     */
+    static volatile Comparator<String> methodComparator;
+
+    @Override
+    public void orderMethods( MethodOrdererContext context )
+    {
+        final Comparator<String> comparator = methodComparator;
+        if ( comparator == null )
+        {
+            return;
+        }
+        final String className = context.getTestClass().getName();
+        context.getMethodDescriptors().sort( new Comparator<MethodDescriptor>()
+        {
+            @Override
+            public int compare( MethodDescriptor a, MethodDescriptor b )
+            {
+                return comparator.compare( key( a ), key( b ) );
+            }
+
+            private String key( MethodDescriptor d )
+            {
+                return d.getMethod().getName() + "(" + className + ")";
+            }
+        } );
+    }
+}


### PR DESCRIPTION
The JUnit 5 provider selected whole classes and let the Jupiter engine choose method order, so -Dsurefire.runOrder=testorder controlled class order but not method order for JUnit5 projects. To fix this, we register a MethodOrderer as the default (junit.jupiter.testmethod.order.default) that reuses the existing comparatorForTestMethods(), so a Class#method order file now controls method order on JUnit 5 too. There is no no effect when the run order does not specify methods.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
